### PR TITLE
Slightly improve exercise suggestion

### DIFF
--- a/exercises/04.dom/01.problem.ref/index.tsx
+++ b/exercises/04.dom/01.problem.ref/index.tsx
@@ -20,7 +20,7 @@ function Tilt({ children }: { children: React.ReactNode }) {
 			className="tilt-root"
 			// 🐨 add a ref callback here
 			// the callback should accept a tiltNode parameter (🦺 typed as an
-			// HTMLVanillaTiltElement) and then:
+			// HTMLVanillaTiltElement | null) and then:
 			// - if tiltNode is null, return
 			// - call VanillaTilt.init(tiltNode, vanillaTiltOptions)
 			// - return a cleanup function that will be called when element is removed


### PR DESCRIPTION
This was unclear to me when working on the exercise - I thought when it very explicitly mentions the HTMLVanillaTiltElement as the type, that it cannot be null and that what we need to assert is tiltNode.vanillaTilt which can be nullish.